### PR TITLE
Further isolate environment variables to fix inconsistent results

### DIFF
--- a/common/common_constants.py
+++ b/common/common_constants.py
@@ -3,5 +3,4 @@ CAUSAL_ANALYSIS_EMAIL_BODY = "Please find the causal analysis results in the pdf
 EMAIL = "admin@causalbench.org"
 REPLY_TO_ADDRESS = "contact@causalbench.org"
 EMAIL_PASSWORD = ""
-TEMP_DIR = "/tmp"
 RANDOM_SEED = 42

--- a/common/yaml_to_csv.py
+++ b/common/yaml_to_csv.py
@@ -6,12 +6,7 @@ import pandas as pd
 from rapidfuzz import process, fuzz
 from causalbench.modules import Dataset
 from causalbench.modules import Run
-from causalbench.modules.context import Context
 
-from common.common_constants import TEMP_DIR
-
-
-os.environ["MPLCONFIGDIR"] = os.path.join(TEMP_DIR, "mplconfig")
 
 # Set working directory to parent dir
 # parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))

--- a/helper_services/causal_analysis_helper.py
+++ b/helper_services/causal_analysis_helper.py
@@ -1,19 +1,13 @@
 from collections import defaultdict
-import shutil
 import os
-import tempfile
 from urllib.parse import urlparse
 import pandas as pd
 import numpy as np
-import requests
 import networkx as nx
 from dowhy import CausalModel
-from common.common_constants import RANDOM_SEED, TEMP_DIR
+from common.common_constants import RANDOM_SEED
 from common.yaml_to_csv import main as process_yaml_data, headers
 from sklearn.preprocessing import LabelEncoder, StandardScaler
-
-
-os.environ["MPLCONFIGDIR"] = os.path.join(TEMP_DIR, "mplconfig")
 
 
 def compute_CATE(data, treatment, outcome, graph):

--- a/helper_services/download_helper.py
+++ b/helper_services/download_helper.py
@@ -24,7 +24,7 @@ def download_zip_from_url(url, download_dir):
             for chunk in response.iter_content(chunk_size=8192):
                 f.write(chunk)
         
-        print(f"Downloaded: {filename}")
+        print(f"Downloaded: {filepath}")
         return filepath
         
     except Exception as e:

--- a/helper_services/report_helper.py
+++ b/helper_services/report_helper.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 import numpy as np
 from openpyxl.styles import Font
 from openpyxl.utils import get_column_letter
@@ -13,8 +14,6 @@ from datetime import datetime, timezone
 
 import yaml
 
-from common.common_constants import TEMP_DIR
-
 
 def generate_report(outcome_column, causal_analysis_results, unique_id, run_ids, filters):
     # Set up parameters
@@ -23,7 +22,7 @@ def generate_report(outcome_column, causal_analysis_results, unique_id, run_ids,
 
     # Create a YAML file
     yaml_filename = f"causal_analysis_results_{timestamp}-{unique_id}.yaml"
-    yaml_filepath = os.path.join(TEMP_DIR, yaml_filename)
+    yaml_filepath = os.path.join(tempfile.gettempdir(), yaml_filename)
     
     with open(yaml_filepath, 'w') as yaml_file:
         yaml.dump(causal_analysis_results, yaml_file, default_flow_style=False, indent=4, sort_keys=False)
@@ -32,7 +31,7 @@ def generate_report(outcome_column, causal_analysis_results, unique_id, run_ids,
 
     # Create a PDF document
     pdf_filename = f"causal_explanation_report_{timestamp}-{unique_id}.pdf"
-    pdf_filepath = os.path.join(TEMP_DIR, pdf_filename)
+    pdf_filepath = os.path.join(tempfile.gettempdir(), pdf_filename)
     doc = SimpleDocTemplate(
         pdf_filepath,
         pagesize=LETTER,
@@ -44,7 +43,7 @@ def generate_report(outcome_column, causal_analysis_results, unique_id, run_ids,
 
     # Create an Excel file
     xlsx_filename = f"causal_recommendations_{timestamp}-{unique_id}.xlsx"
-    xlsx_filepath = os.path.join(TEMP_DIR, xlsx_filename)
+    xlsx_filepath = os.path.join(tempfile.gettempdir(), xlsx_filename)
 
     # Colors
     tab_h_bg_col = colors.HexColor("#95979d")    # table header background color

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -1,6 +1,8 @@
 import atexit
 from collections import defaultdict
 import os
+from tempfile import tempdir
+import tempfile
 
 import causalbench
 from helper_services.causal_analysis_helper import run_causal_analysis
@@ -12,15 +14,35 @@ from helper_services.report_helper import generate_report
 from helper_services.hp_dtype_helper import get_hp_dtypes
 from helper_services.mail_helper import send_email
 import numpy as np
-from common.common_constants import CAUSAL_ANALYSIS_EMAIL_BODY, TEMP_DIR
+from common.common_constants import CAUSAL_ANALYSIS_EMAIL_BODY
+
+
+
+def configure_env():
+    """
+    Directory setup to ensure isolation
+    """
+    # fake temporary directory
+    TEMP_DIR = tempfile.mkdtemp()
+    tempfile.tempdir = None
+    os.environ["TMPDIR"] = TEMP_DIR
+    os.environ["TEMP"] = TEMP_DIR
+    os.environ["TMP"] = TEMP_DIR
+
+    # fake home directory
+    HOME_DIR = os.path.join(TEMP_DIR, "home")
+    os.makedirs(HOME_DIR, exist_ok=True)
+    os.environ["HOME"] = HOME_DIR
+    os.environ["USERPROFILE"] = HOME_DIR
+
+    # fake mpl config directory
+    os.environ["MPLCONFIGDIR"] = os.path.join(TEMP_DIR, "mplconfig")
 
 
 def handler(event, context):
-    # create fake home to ensure isolation
-    fake_home = os.path.abspath(os.path.join(TEMP_DIR, "home"))
-    os.makedirs(fake_home, exist_ok=True)
-    os.environ["HOME"] = fake_home
-    os.environ["USERPROFILE"] = fake_home
+    # configure the environment variables
+    configure_env()
+    print(tempfile.gettempdir())
 
     # set JWT token
     causalbench.services.auth.__access_token = event.get('jwt_token', None)

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -12,7 +12,6 @@ from helper_services.report_helper import generate_report
 from helper_services.hp_dtype_helper import get_hp_dtypes
 from helper_services.mail_helper import send_email
 import numpy as np
-from common.common_constants import CAUSAL_ANALYSIS_EMAIL_BODY
 
 
 

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -1,4 +1,3 @@
-import atexit
 from collections import defaultdict
 import os
 from tempfile import tempdir
@@ -83,8 +82,7 @@ def handler(event, context):
         try:
             if len(dimensions) > 0:
                 cols = ["HP." + dim for dim in dimensions.keys()]
-                # data = list(group_data["data"][cols].itertuples(index=False, name=None))
-                # group_data['recommendations'] = run_causal_recommendation(data, dimensions, hp_dtypes, max_points)
+                
                 sample_frame = group_data["data"][cols + ["outcome"]].copy()
                 group_data['recommendations'] = run_g2s_causal_recommendation(sample_frame, dimensions, hp_dtypes, max_points)
             else:
@@ -106,11 +104,6 @@ def handler(event, context):
         send_email(event.get('user_email'), "[CausalBench] Causal Analysis Results", CAUSAL_ANALYSIS_EMAIL_BODY, attachments=attachments)
     except Exception as e:
         print(f"Error sending email: {e}")
-    
-    # # remove the attachments after sending the email
-    # for attachment in attachments:
-    #     if os.path.exists(attachment):
-    #         atexit.register(lambda path=attachment: os.remove(path))
     
     response = {
         "analysis_results": causal_analysis_results

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -12,7 +12,6 @@ from helper_services.report_helper import generate_report
 from helper_services.hp_dtype_helper import get_hp_dtypes
 from helper_services.mail_helper import send_email
 import numpy as np
-from common.common_constants import TEMP_DIR
 
 
 def build_email_body(causal_analysis_results, event):

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -22,20 +22,20 @@ def configure_env():
     Directory setup to ensure isolation
     """
     # fake temporary directory
-    TEMP_DIR = tempfile.mkdtemp()
+    temp_dir = tempfile.mkdtemp()
     tempfile.tempdir = None
-    os.environ["TMPDIR"] = TEMP_DIR
-    os.environ["TEMP"] = TEMP_DIR
-    os.environ["TMP"] = TEMP_DIR
+    os.environ["TMPDIR"] = temp_dir
+    os.environ["TEMP"] = temp_dir
+    os.environ["TMP"] = temp_dir
 
     # fake home directory
-    HOME_DIR = os.path.join(TEMP_DIR, "home")
-    os.makedirs(HOME_DIR, exist_ok=True)
-    os.environ["HOME"] = HOME_DIR
-    os.environ["USERPROFILE"] = HOME_DIR
+    home_dir = os.path.join(temp_dir, "home")
+    os.makedirs(home_dir, exist_ok=True)
+    os.environ["HOME"] = home_dir
+    os.environ["USERPROFILE"] = home_dir
 
     # fake mpl config directory
-    os.environ["MPLCONFIGDIR"] = os.path.join(TEMP_DIR, "mplconfig")
+    os.environ["MPLCONFIGDIR"] = os.path.join(temp_dir, "mplconfig")
 
 
 def handler(event, context):

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -14,6 +14,54 @@ from helper_services.mail_helper import send_email
 import numpy as np
 
 
+def build_email_body(causal_analysis_results, event):
+    outcome_column = event.get('outcome_column', 'Time.Duration')
+    filters = event.get('filters', None)
+    metadata = causal_analysis_results.get('_metadata', {})
+
+    experiment_count = metadata.get('experiment_count', 0)
+    insufficient_data = metadata.get('insufficient_data', False)
+    insufficient_data_reason = metadata.get('insufficient_data_reason', None)
+
+    lines = ["CausalBench+ Causal Analysis Report", ""]
+    lines.append(f"Outcome metric: {outcome_column}")
+    lines.append(f"Experiments: Effects on {outcome_column} ({experiment_count} experiments)")
+
+    if filters:
+        filter_str = ", ".join(f"{k}={v}" for k, v in filters.items()) if isinstance(filters, dict) else str(filters)
+        lines.append(f"Filters applied: {filter_str}")
+
+    lines.append("")
+
+    if insufficient_data:
+        lines.append("INSUFFICIENT DATA: Causal effects could not be computed.")
+        if insufficient_data_reason:
+            lines.append(f"Reason: {insufficient_data_reason}")
+        lines.append("")
+        lines.append("To get results, run more experiments with varied hyperparameter configurations.")
+        lines.append("Minimum requirements: ≥ 2 data points per variable, ≥ 2 unique values per hyperparameter.")
+    else:
+        all_effects = {}
+        for group, group_data in causal_analysis_results.items():
+            if group == "_metadata":
+                continue
+            for k, v in group_data.get("effects", {}).items():
+                if isinstance(v, (int, float)) and math.isfinite(v):
+                    all_effects[k] = v
+
+        if all_effects:
+            sorted_effects = sorted(all_effects.items(), key=lambda x: abs(x[1]), reverse=True)[:3]
+            lines.append("Top causal effects:")
+            for hp, effect in sorted_effects:
+                hp_name = hp.split(".", 1)[1] if "." in hp else hp
+                sign = "+" if effect >= 0 else ""
+                lines.append(f"  {hp_name}: {sign}{effect:.4f}")
+
+    lines.append("")
+    lines.append("Full results are in the attached PDF report.")
+
+    return "\n".join(lines)
+
 
 def configure_env():
     """

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -12,55 +12,29 @@ from helper_services.report_helper import generate_report
 from helper_services.hp_dtype_helper import get_hp_dtypes
 from helper_services.mail_helper import send_email
 import numpy as np
+from common.common_constants import CAUSAL_ANALYSIS_EMAIL_BODY
 
 
-def build_email_body(causal_analysis_results, event):
-    outcome_column = event.get('outcome_column', 'Time.Duration')
-    filters = event.get('filters', None)
-    metadata = causal_analysis_results.get('_metadata', {})
 
-    experiment_count = metadata.get('experiment_count', 0)
-    insufficient_data = metadata.get('insufficient_data', False)
-    insufficient_data_reason = metadata.get('insufficient_data_reason', None)
+def configure_env():
+    """
+    Directory setup to ensure isolation
+    """
+    # fake temporary directory
+    temp_dir = tempfile.mkdtemp()
+    tempfile.tempdir = None
+    os.environ["TMPDIR"] = temp_dir
+    os.environ["TEMP"] = temp_dir
+    os.environ["TMP"] = temp_dir
 
-    lines = ["CausalBench+ Causal Analysis Report", ""]
-    lines.append(f"Outcome metric: {outcome_column}")
-    lines.append(f"Experiments: Effects on {outcome_column} ({experiment_count} experiments)")
+    # fake home directory
+    home_dir = os.path.join(temp_dir, "home")
+    os.makedirs(home_dir, exist_ok=True)
+    os.environ["HOME"] = home_dir
+    os.environ["USERPROFILE"] = home_dir
 
-    if filters:
-        filter_str = ", ".join(f"{k}={v}" for k, v in filters.items()) if isinstance(filters, dict) else str(filters)
-        lines.append(f"Filters applied: {filter_str}")
-
-    lines.append("")
-
-    if insufficient_data:
-        lines.append("INSUFFICIENT DATA: Causal effects could not be computed.")
-        if insufficient_data_reason:
-            lines.append(f"Reason: {insufficient_data_reason}")
-        lines.append("")
-        lines.append("To get results, run more experiments with varied hyperparameter configurations.")
-        lines.append("Minimum requirements: ≥ 2 data points per variable, ≥ 2 unique values per hyperparameter.")
-    else:
-        all_effects = {}
-        for group, group_data in causal_analysis_results.items():
-            if group == "_metadata":
-                continue
-            for k, v in group_data.get("effects", {}).items():
-                if isinstance(v, (int, float)) and math.isfinite(v):
-                    all_effects[k] = v
-
-        if all_effects:
-            sorted_effects = sorted(all_effects.items(), key=lambda x: abs(x[1]), reverse=True)[:3]
-            lines.append("Top causal effects:")
-            for hp, effect in sorted_effects:
-                hp_name = hp.split(".", 1)[1] if "." in hp else hp
-                sign = "+" if effect >= 0 else ""
-                lines.append(f"  {hp_name}: {sign}{effect:.4f}")
-
-    lines.append("")
-    lines.append("Full results are in the attached PDF report.")
-
-    return "\n".join(lines)
+    # fake mpl config directory
+    os.environ["MPLCONFIGDIR"] = os.path.join(temp_dir, "mplconfig")
 
 
 def handler(event, context):

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 import os
-from tempfile import tempdir
 import tempfile
 
 import causalbench

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -41,7 +41,6 @@ def configure_env():
 def handler(event, context):
     # configure the environment variables
     configure_env()
-    print(tempfile.gettempdir())
 
     # set JWT token
     causalbench.services.auth.__access_token = event.get('jwt_token', None)


### PR DESCRIPTION
When a causal analysis was performed multiple times, the number of experiments considered were different. I found that the issue was due to AWS Lambda instances being reused, which led to some old intermediate files not being deleted, causing erroneous results. I have implemented isolation of executions so each execution will write to a separate directory, thus avoiding any overlaps.